### PR TITLE
Fix issue with parsing of installed/install output from yum

### DIFF
--- a/files/os_patching_fact_generation.ps1
+++ b/files/os_patching_fact_generation.ps1
@@ -1,0 +1,1 @@
+$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8';Import-Module PSWindowsUpdate; Get-WUList -WindowsUpdate | Format-List -Property Title > C:\ProgramData\PuppetLabs\puppet\cache\package_updates

--- a/lib/facter/os_patching.rb
+++ b/lib/facter/os_patching.rb
@@ -9,7 +9,6 @@ if Facter.value(:facterversion).split('.')[0].to_i < 2
   end
 else
   Facter.add('os_patching', :type => :aggregate) do
-
     require 'time'
     now = Time.now.iso8601
 
@@ -26,7 +25,7 @@ else
       if File.file?(updatefile)
         updates = File.open(updatefile, 'r').read
         updates.each_line do |line|
-          next unless line.match(/[A-Za-z0-9]+/)
+          next unless line =~ /[A-Za-z0-9]+/
           next if line.include? '^#'
           line.sub! 'Title : ', ''
           updatelist.push line.chomp

--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -306,7 +306,7 @@ if facts['os']['family'] == 'RedHat'
     updated_packages, stderr, status = Open3.capture3("yum history info #{job}")
     err(status, 'os_patching/yum', stderr, starttime) if status != 0
     updated_packages.split("\n").each do |line|
-      matchdata = line.match(/^\s+(Installed|Upgraded|Erased|Updated)\s+(\S+)\s/)
+      matchdata = line.match(/^\s+(Install|Upgraded|Erased|Updated)\s+(\S+)\s/)
       next unless matchdata
       pkg_hash[matchdata[2]] = matchdata[1]
     end


### PR DESCRIPTION
Looks like some packages show as "Installed XXX" and some as "Install XXX", the regex was previously looking for "Installed", changed it to "Install" as that'll catch both.