### PR TITLE
Issue/133 eventlog puppet agent 6.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This shows there are no updates which can be applied to this server and the serv
 }
 ```
 
-Where it shows 6 packages with available updates, along with an array of the package names.  None of the packges are tagged as security related (requires Debian, a subscription to RHEL or a Windows system).  There are no blockers to patching and the blackout window defined is not in effect.
+Where it shows 6 packages with available updates, along with an array of the package names.  None of the packages are tagged as security related (requires Debian, a subscription to RHEL or a Windows system).  There are no blockers to patching and the blackout window defined is not in effect.
 
 The reboot_required flag is set to true, which means there have been changes to packages that require a reboot (libc, kernel etc) but a reboot hasn't happened.  The apps_needing_restart shows the PID and command line of applications that are using files that have been upgraded but the process hasn't been restarted.
 
@@ -308,11 +308,11 @@ As Windows includes no native command line tools to manage update installation, 
 
 #### Supported Windows Versions
 
-Windows Server 2008 (x86 and x64) through to 2019 have been tested. The code should also function on the equivelant client versions of Windows (e.g. Vista and newer), however this has not been thoroughly tested.
+Windows Server 2008 (x86 and x64) through to 2019 have been tested. The code should also function on the equivalent client versions of Windows (e.g. Vista and newer), however this has not been thoroughly tested.
 
 #### Configuration of Windows Update
 
-This module does *not* handle the configuration of the update source or any of the other Windows Update settings - it simply triggers a search (fact generation) or searc, download and install (patch_server task). It is recommended to use the [puppetlabs wsus_client module](https://forge.puppet.com/puppetlabs/wsus_client) to configure the followng options:
+This module does *not* handle the configuration of the update source or any of the other Windows Update settings - it simply triggers a search (fact generation) or searc, download and install (patch_server task). It is recommended to use the [puppetlabs wsus_client module](https://forge.puppet.com/puppetlabs/wsus_client) to configure the following options:
 
 * WSUS server if you are using one (although this is not strictly required)
 * Set the mode to automatically download updates and notify for install (`AutoNotify`)
@@ -335,7 +335,7 @@ class { 'wsus_client':
 
 * If updates or packages are installed outside of this script (e.g. by a user or another automated process), the results will not be captured in the facts.
 
-* On Windows systems, the timeout parameter of the `patch_server` task is implemented as a maintenace window end time (e.g. start time + timeout). This is used by doing a calculation prior to installing each update. If there is insufficient available, the update run will stop. However, at this stage each update is estimated to take 5 minutes to install. This will be improved in a future release to perform an estimation based on update size or type (e.g. an SCCM-like 5 minutes for hotfix, 30 minutes for cumulative update).
+* On Windows systems, the timeout parameter of the `patch_server` task is implemented as a maintenance window end time (e.g. start time + timeout). This is used by doing a calculation prior to installing each update. If there is insufficient available, the update run will stop. However, at this stage each update is estimated to take 5 minutes to install. This will be improved in a future release to perform an estimation based on update size or type (e.g. an SCCM-like 5 minutes for hotfix, 30 minutes for cumulative update).
 
 ## Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -336,7 +336,7 @@ class os_patching (
           {
             schedule         => daily,
             start_time       => "01:${patch_cron_min}",
-            minutes_interval => '60',
+            minutes_interval => '720',
           },
           {
             schedule => 'boot',

--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -15,7 +15,7 @@ if IS_WINDOWS
   # windows
   # use ruby file logger
   require 'logger'
-  log = Logger.new('C:/ProgramData/os_patching/os_patching_task.log','monthly')
+  log = Logger.new('C:/ProgramData/os_patching/os_patching_task.log', 'monthly')
   # set paths/commands for windows
   fact_generation_script = 'C:/ProgramData/os_patching/os_patching_fact_generation.ps1'
   fact_generation_cmd = "#{ENV['systemroot']}/system32/WindowsPowerShell/v1.0/powershell.exe -ExecutionPolicy RemoteSigned -file #{fact_generation_script}"
@@ -179,7 +179,7 @@ def err(code, kind, message, starttime)
     # windows
     # use ruby file logger
     require 'logger'
-    log = Logger.new('C:/ProgramData/os_patching/os_patching_task.log','monthly')
+    log = Logger.new('C:/ProgramData/os_patching/os_patching_task.log', 'monthly')
   else
     # not windows
     # create syslog logger

--- a/tasks/refresh_fact.rb
+++ b/tasks/refresh_fact.rb
@@ -1,65 +1,20 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
-# windows logging class
-class WinLog
-  def initialize
-    require 'win32/eventlog'
-
-    # log to send events to
-    windows_log = 'Application'
-
-    # source of event shown in event log
-    @event_source = 'os_patching'
-
-    # add event source if needed
-    # we probably should generate and register an mc file, but the events still show without it
-    Win32::EventLog.add_event_source(:source => windows_log, :key_name => @event_source)
-
-    # create logger
-    @logger = Win32::EventLog.new
-  end
-
-  # match SysLog::Logger event types
-
-  def debug(data)
-    @logger.report_event(:event_type => Win32::EventLog::INFO_TYPE, :data => "Debug: #{data}", :source => @event_source)
-  end
-
-  def error(data)
-    @logger.report_event(:event_type => Win32::EventLog::ERROR_TYPE, :data => data, :source => @event_source)
-  end
-
-  def fatal(data)
-    @logger.report_event(:event_type => Win32::EventLog::ERROR_TYPE, :data => "FATAL: #{data}", :source => @event_source)
-  end
-
-  def info(data)
-    @logger.report_event(:event_type => Win32::EventLog::INFO_TYPE, :data => data, :source => @event_source)
-  end
-
-  def unknown(data)
-    @logger.report_event(:event_type => Win32::EventLog::INFO_TYPE, :data => "Unknown: #{data}", :source => @event_source)
-  end
-
-  def warn(data)
-    @logger.report_event(:event_type => Win32::EventLog::WARN_TYPE, :data => data, :source => @event_source)
-  end
-end
-
 require 'rbconfig'
 require 'open3'
 require 'json'
 require 'time'
 require 'timeout'
 
-is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
+IS_WINDOWS = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
 
 $stdout.sync = true
 
-if is_windows
+if IS_WINDOWS
   # windows
-  # create windows event logger
-  log = WinLog.new
+  # use ruby file logger
+  require 'logger'
+  log = Logger.new('C:/ProgramData/os_patching/os_patching_refresh_fact_task.log','monthly')
   # set paths/commands for windows
   fact_generation_script = 'C:/ProgramData/os_patching/os_patching_fact_generation.ps1'
   fact_generation_cmd = "#{ENV['systemroot']}/system32/WindowsPowerShell/v1.0/powershell.exe -ExecutionPolicy RemoteSigned -file #{fact_generation_script}"
@@ -105,13 +60,17 @@ def err(code, kind, message, starttime)
   }
 
   puts JSON.pretty_generate(json)
-  shortmsg = message.split("\n").first.chomp
-  history(starttime, shortmsg, exitcode, '', '', '')
-  log = if is_windows
-          WinLog.new
-        else
-          Syslog::Logger.new 'os_patching'
-        end
+  if IS_WINDOWS
+    # windows
+    # use ruby file logger
+    require 'logger'
+    log = Logger.new('C:/ProgramData/os_patching/os_patching_refresh_fact_task.log','monthly')
+  else
+    # not windows
+    # create syslog logger
+    require 'syslog/logger'
+    log = Syslog::Logger.new 'os_patching'
+  end
   log.error "ERROR : #{kind} : #{exitcode} : #{message}"
   exit(exitcode.to_i)
 end
@@ -120,7 +79,7 @@ end
 refresh_out, stderr, status = Open3.capture3(fact_generation_cmd)
 
 # make output more readable if on windows
-refresh_out_log = if is_windows
+refresh_out_log = if IS_WINDOWS
                     refresh_out.split("\n")
                   else
                     refresh_out

--- a/tasks/refresh_fact.rb
+++ b/tasks/refresh_fact.rb
@@ -14,7 +14,7 @@ if IS_WINDOWS
   # windows
   # use ruby file logger
   require 'logger'
-  log = Logger.new('C:/ProgramData/os_patching/os_patching_refresh_fact_task.log','monthly')
+  log = Logger.new('C:/ProgramData/os_patching/os_patching_refresh_fact_task.log', 'monthly')
   # set paths/commands for windows
   fact_generation_script = 'C:/ProgramData/os_patching/os_patching_fact_generation.ps1'
   fact_generation_cmd = "#{ENV['systemroot']}/system32/WindowsPowerShell/v1.0/powershell.exe -ExecutionPolicy RemoteSigned -file #{fact_generation_script}"
@@ -64,7 +64,7 @@ def err(code, kind, message, starttime)
     # windows
     # use ruby file logger
     require 'logger'
-    log = Logger.new('C:/ProgramData/os_patching/os_patching_refresh_fact_task.log','monthly')
+    log = Logger.new('C:/ProgramData/os_patching/os_patching_refresh_fact_task.log', 'monthly')
   else
     # not windows
     # create syslog logger


### PR DESCRIPTION
Changed patch_server and refresh_fact from using the windows event log with the win32-eventlog gem to a simple file log with the stdlib logger library, as it seems this gem is no longer included as part of the puppet agent. This fixes issue #133.

Changed the fact refresh scheduled task on windows to repeat every 12 hours rather than hourly. Windows update scans can take lots of system resources and by default are only repeated daily, so 12 hourly should be more than enough.

Corrected a couple of spelling mistakes in the readme.