### PR TITLE
Force usage of the 'C' locale

### DIFF
--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -31,6 +31,8 @@ else
   fact_generation_cmd = fact_generation_script
   puppet_cmd = '/opt/puppetlabs/puppet/bin/puppet'
   shutdown_cmd = 'nohup /sbin/shutdown -r +1 2>/dev/null 1>/dev/null &'
+
+  ENV['LC_ALL'] = 'C'
 end
 
 starttime = Time.now.iso8601


### PR DESCRIPTION
When parsing command output, we should ensure the utility will emit messages in the language we are using for matching patterns.  Force the locale to be 'C' by setting the LC_ALL environment variable.

This fix this kind of problems:

```sh-session
romain@marvin ~ % bolt task run os_patching::patch_server reboot=smart -n target.example.com    
Started on target.example.com...
Failed on target.example.com:
  Task exited : 0
  yum return code not found
  {
  }
Failed on 1 node: target.example.com
Ran on 1 node in 458.48 seconds
romain@marvin ~ %
```