### PR TITLE
Bugfix: Add missing dependency

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -292,7 +292,10 @@ class os_patching (
           user        => $patch_data_owner,
           group       => $patch_data_group,
           refreshonly => true,
-          require     => File[$fact_cmd],
+          require     => [
+            File[$fact_cmd],
+            File["${cache_dir}/reboot_override"]
+          ],
         }
       }
 

--- a/spec/classes/os_patching_spec.rb
+++ b/spec/classes/os_patching_spec.rb
@@ -110,6 +110,9 @@ describe 'os_patching' do
       when 'Linux'
         it { is_expected.to contain_cron('Cache patching data').with_ensure('present') }
         it { is_expected.to contain_cron('Cache patching data at reboot').with_ensure('present') }
+        it { is_expected.to contain_exec('os_patching::exec::fact').that_requires(
+            'File[' + cache_dir + '/reboot_override]'
+        )}
       end
       it { is_expected.to contain_exec('os_patching::exec::fact') }
       it { is_expected.to contain_exec('os_patching::exec::fact_upload') }


### PR DESCRIPTION
The `Exec[os_patching::exec::fact]` resource depends on the "${cache_dir}/reboot_override" file. Without this dependency this puppet script might fail, as follows:

```
Notice: Compiled catalog for 067a7595e6ae in environment production in 0.22 seconds
Notice: /Stage[main]/Os_patching/File[/usr/local/bin/os_patching_fact_generation.sh]/ensure: defined content as '{md5}c79dffc9d34f5f4fabe57302e355f140'
Error: /Stage[main]/Os_patching/Exec[os_patching::exec::fact]: Failed to call refresh: /usr/local/bin/os_patching_fact_generation.sh returned 1 instead of one of [0]
Error: /Stage[main]/Os_patching/Exec[os_patching::exec::fact]: /usr/local/bin/os_patching_fact_generation.sh returned 1 instead of one of [0]
Notice: /Stage[main]/Os_patching/Cron[Cache patching data]/ensure: created
Notice: /Stage[main]/Os_patching/Cron[Cache patching data at reboot]/ensure: created
Notice: /Stage[main]/Os_patching/File[/var/cache/os_patching]/ensure: created
Notice: /Stage[main]/Os_patching/File[/var/cache/os_patching/reboot_override]/ensure: defined content as '{md5}c21f969b5f03d33d43e04f8f136e7682'
```

Tested on a Linux machine.