### PR TITLE
Fix handling of KBArticleIDs

### DIFF
--- a/files/os_patching_fact_generation.ps1
+++ b/files/os_patching_fact_generation.ps1
@@ -286,7 +286,7 @@ function Invoke-RefreshPuppetFacts {
     $allUpdates | Select-Object -ExpandProperty Title | Out-File $updateFile -Encoding ascii
 
     # output list of KBs that need to be applied
-    $allUpdates | ForEach-Object { ($_ | Select-Object -ExpandProperty KBArticleIDs)[0] } | Out-File $kbFile -Encoding ascii
+    $allUpdates | ForEach-Object { $_.KBArticleIDs | ForEach-Object { "KB$_" } } | Out-File $kbFile -Encoding ascii
 
     # filter to security updates and output
     $securityUpdates | Select-Object -ExpandProperty Title | Out-File $secUpdateFile -Encoding ascii

--- a/lib/facter/os_patching.rb
+++ b/lib/facter/os_patching.rb
@@ -54,7 +54,7 @@ else
           kblist.push line.chomp
         end
       end
-      data['missing_update_kbs'] = kbslist
+      data['missing_update_kbs'] = kblist
       data
     end
 


### PR DESCRIPTION
- Ensures all KBArticleIDs are processed, not just the first one in the array
- Ensures the ID's start with "KB", which aids reusing the fact info later on.
- Fixes a typo in os_patching.rb