### PR TITLE
Prevent error message to stderr on RedHat

### DIFF
--- a/files/os_patching_fact_generation.sh
+++ b/files/os_patching_fact_generation.sh
@@ -28,7 +28,7 @@ case $(facter osfamily) in
     FILTER='egrep -v "^Security:"'
     PKGS=$(yum -q check-update 2>/dev/null| $FILTER | egrep -v "is broken|^Loaded plugins" | awk '/^[[:alnum:]]/ {print $1}')
     SECPKGS=$(yum -q --security check-update 2>/dev/null| $FILTER | egrep -v "is broken|^Loaded plugins" | awk '/^[[:alnum:]]/ {print $1}')
-    HELDPKGS=$(awk -F':' '/:/ {print $2}' /etc/yum/pluginconf.d/versionlock.list | sed 's/-[0-9].*//'
+    HELDPKGS=$([ -r /etc/yum/pluginconf.d/versionlock.list ] && awk -F':' '/:/ {print $2}' /etc/yum/pluginconf.d/versionlock.list | sed 's/-[0-9].*//'
 )
   ;;
   Suse)


### PR DESCRIPTION
If the file `/etc/yum/pluginconf.d/versionlock.list` does not exist, awk will output a diagnostic message to stderr:

```
awk: fatal: cannot open file `/etc/yum/pluginconf.d/versionlock.list' for reading (No such file or directory)
```

Because the `os_patching_fact_generation.sh` script is run by cron, an e-mail is sent to the root user every hour with this error message.

Ensure the file exist and is readable and only in this case check it's content to avoid unexpected messages.