### PR TITLE
Inconsistence between facter and manifest

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,8 +264,8 @@ class os_patching (
   if ($blackout_windows) {
     # Validate the information in the blackout_windows hash
     $blackout_windows.each | String $key, Hash $value | {
-      if ( $key !~ /^[A-Za-z0-9 ]+$/ ){
-        fail translate(('Blackout description can only contain alphanumerics and space'))
+      if ( $key !~ /^[A-Za-z0-9_ ]+$/ ){
+        fail translate(('Blackout description can only contain alphanumerics, space and underscore'))
       }
       if ( $value['start'] !~ /^\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2}$/ ){
         fail translate(('Blackout start time must be in ISO 8601 format (YYYY-MM-DDTmm:hh:ss[-+]hh:mm)'))

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,8 +264,8 @@ class os_patching (
   if ($blackout_windows) {
     # Validate the information in the blackout_windows hash
     $blackout_windows.each | String $key, Hash $value | {
-      if ( $key !~ /^[A-Za-z0-9\-_ ]+$/ ){
-        fail translate(('Blackout description can only contain alphanumerics, space, dash and underscore'))
+      if ( $key !~ /^[A-Za-z0-9 ]+$/ ){
+        fail translate(('Blackout description can only contain alphanumerics and space'))
       }
       if ( $value['start'] !~ /^\d{,4}-\d{1,2}-\d{1,2}T\d{,2}:\d{,2}:\d{,2}[-\+]\d{,2}:\d{,2}$/ ){
         fail translate(('Blackout start time must be in ISO 8601 format (YYYY-MM-DDTmm:hh:ss[-+]hh:mm)'))


### PR DESCRIPTION
Blackout regex on (os_patching.rb line 94) and init are different. 

Using a title "Xmas-2019-2020" will be validated by init but not by os_patching.rb. Facter will output: 

` warnings => {
    blackouts => "Invalid blackout entry : Xmas-2019-2020,2019-12-20T12:00:00+00:00,2020-01-02T09:00:00+00:00
"
  },
  blocked => true,
  blocked_reasons => [
    "Invalid blackout entry : Xmas-2019-2020,2019-12-20T12:00:00+00:00,2020-01-02T09:00:00+00:00
"
  ]
`