### PR TITLE
Improve os_patching::patch_after_healthcheck plan

### DIFF
--- a/plans/patch_after_healthcheck.pp
+++ b/plans/patch_after_healthcheck.pp
@@ -20,6 +20,6 @@ plan os_patching::patch_after_healthcheck (TargetSpec $nodes) {
   $skipped_targets = $nodes_skipped.map | $value | { $value['certname'] }
   $targets = $nodes_to_patch.map | $value | { $value['certname'] }
 
-  #notice ("Skipping the following nodes due to health check failures : ${nodes_skipped}")
+  out::message("Skipping the following nodes due to health check failures : ${nodes_skipped}")
   return run_task('os_patching::patch_server', $targets)
 }

--- a/plans/patch_after_healthcheck.pp
+++ b/plans/patch_after_healthcheck.pp
@@ -2,15 +2,19 @@
 #   [puppet health check](https://forge.puppet.com/albatrossflavour/puppet_health_check)
 #   module to perform a pre-check on the nodes you're planning to patch.  If the nodes pass the
 #   check, they get patched
-plan os_patching::patch_after_healthcheck (TargetSpec $nodes) {
+plan os_patching::patch_after_healthcheck (
+  TargetSpec $nodes
+  Optional[Boolean] $noop_state = false
+  Optional[Integer] $runinterval = 1800
+  ) {  
   # Run an initial health check to make sure the target nodes are ready
 
   $health_checks = run_task('puppet_health_check::agent_health',
                             $nodes,
-                            target_noop_state      => false,
+                            target_noop_state      => $noop_state,
                             target_service_enabled => true,
                             target_service_running => true,
-                            target_runinterval     => 14400,
+                            target_runinterval     => $runinterval,
                             '_catch_errors'        => true,
   )
 

--- a/plans/patch_after_healthcheck.pp
+++ b/plans/patch_after_healthcheck.pp
@@ -3,9 +3,9 @@
 #   module to perform a pre-check on the nodes you're planning to patch.  If the nodes pass the
 #   check, they get patched
 plan os_patching::patch_after_healthcheck (
-  TargetSpec $nodes
-  Optional[Boolean] $noop_state = false
-  Optional[Integer] $runinterval = 1800
+  TargetSpec $nodes,
+  Optional[Boolean] $noop_state = false,
+  Optional[Integer] $runinterval = 1800,
   ) {  
   # Run an initial health check to make sure the target nodes are ready
 

--- a/plans/patch_after_healthcheck.pp
+++ b/plans/patch_after_healthcheck.pp
@@ -10,7 +10,7 @@ plan os_patching::patch_after_healthcheck (TargetSpec $nodes) {
                             target_noop_state      => false,
                             target_service_enabled => true,
                             target_service_running => true,
-                            target_runinterval     => 1800,
+                            target_runinterval     => 14400,
                             '_catch_errors'        => true,
   )
 
@@ -20,6 +20,6 @@ plan os_patching::patch_after_healthcheck (TargetSpec $nodes) {
   $skipped_targets = $nodes_skipped.map | $value | { $value['certname'] }
   $targets = $nodes_to_patch.map | $value | { $value['certname'] }
 
-  notice ("Skipping the following nodes due to health check failures : ${nodes_skipped}")
+  #notice ("Skipping the following nodes due to health check failures : ${nodes_skipped}")
   return run_task('os_patching::patch_server', $targets)
 }


### PR DESCRIPTION
This PR makes the following improvements to the `os_patching::patch_after_healthcheck` plan:
* replaces the `notice()` function with the `out::message()` function, necessary for PE Plans compatibility
* provides optional plan parameters for `runinterval` and `noop_state`, so that environments with non-default settings for these two options can still make use of the plan