### PR TITLE
fix(patch_server) change regex after yum history

### DIFF
--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -476,7 +476,7 @@ if facts['values']['os']['family'] == 'RedHat'
       # ID     | Login user               | Date and time    | 8< SNIP >8
       # ------------------------------------------------------ 8< SNIP >8
       #     69 | System <unset>           | 2018-09-17 17:18 | 8< SNIP >8
-      matchdata = line.to_s.match(/^\s+(\d+)\s*\|\s*[\w\-<> ]*\|\s*([\d:\- ]*)/)
+      matchdata = line.to_s.match(/^\s+(\d+)\s*\|\s*.*?\|\s*([\d:\- ]*)\s|.*/)
       next unless matchdata
       job = matchdata[1]
       yum_end = matchdata[2]


### PR DESCRIPTION
when names are too long yum history truncates and replaces names by
'...'
```
ID     | Login user               | Date and time    | Action(s)      |
Altered
-------------------------------------------------------------------------------
    66 | Foo ... <foo>    | 2020-01-24 16:10 | Update         |    1
    65 | Bar ... <bar>    | 2020-01-24 16:06 | Downgrade      |    1
```
Thanks to @stephanevalk for the regex :) 