### PR TITLE
Change yum check-update to include valid entries instead of exclude invalid

### DIFF
--- a/files/os_patching_fact_generation.sh
+++ b/files/os_patching_fact_generation.sh
@@ -26,9 +26,9 @@ case $(facter osfamily) in
     # ---
     # We need to filter those out as they screw up the package listing
     FILTER='egrep -v "^Security:"'
-    PKGS=$(yum -q check-update 2>/dev/null| $FILTER | egrep -v "is broken|^Loaded plugins" | awk '/^[[:alnum:]]/ {print $1}')
+    PKGS=$(yum -q check-update 2>/dev/null| $FILTER |  egrep -i '^[[:alnum:]_-]+\.[[:alnum:]_-]+[[:space:]]+[[:alnum:]_.-]+[[:space:]]+[A-Za-z0-9_.-]+[[:space:]]*$' | awk '/^[[:alnum:]]/ {print $1}')
     PKGS=$(echo $PKGS | sed 's/Obsoleting.*//')
-    SECPKGS=$(yum -q --security check-update 2>/dev/null| $FILTER | egrep -v "is broken|^Loaded plugins" | awk '/^[[:alnum:]]/ {print $1}')
+    SECPKGS=$(yum -q --security check-update 2>/dev/null| $FILTER | egrep -i '^[[:alnum:]_-]+\.[[:alnum:]_-]+[[:space:]]+[[:alnum:]_.-]+[[:space:]]+[A-Za-z0-9_.-]+[[:space:]]*$' | awk '/^[[:alnum:]]/ {print $1}')
     SECPKGS=$(echo $SECPKGS | sed 's/Obsoleting.*//')
     HELDPKGS=$([ -r /etc/yum/pluginconf.d/versionlock.list ] && awk -F':' '/:/ {print $2}' /etc/yum/pluginconf.d/versionlock.list | sed 's/-[0-9].*//')
   ;;


### PR DESCRIPTION
I have a system where yum is currently outputting this:
```
Update notice RHSA-2019:3193 (from rhel-7-server-rpms) is broken, or a bad duplicate, skipping.
You should report this problem to the owner of the rhel-7-server-rpms repository.
If you are the owner, consider re-running the same command with --verbose to see the exact data that caused the conflict.
```

The "is broken" check excludes that first line, but then I end up with `os_patching.package_updates => [ "You", "If" ]` in my facts and the system doesn't show up as patched.

So, I propose that instead of trying to `egrep -v` away a small set of known problem lines from yum, this should carefully match  lines that match the pattern of the output when a yum update is available. (`${rpmname}.${arch}   ${version}   ${repo}` where all whitespace is variable and lines may have trailing whitespace).