### PR TITLE
Fixing failing development tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ before_install:
   - gem update --system $RUBYGEMS_VERSION
   - gem --version
   - bundle -v
+  - bundle config set without 'system_tests'
 script:
   - 'bundle exec rake $CHECK'
-bundler_args: --without system_tests
 rvm:
   - 2.5.1
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       rvm: 2.5.1
       script:
       - bundle exec rake 'litmus:provision_list[travis_deb]'
-      - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'
+      - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --targets='localhost*'
       - bundle exec rake 'litmus:install_agent[puppet5]'
       - bundle exec rake litmus:install_module
       - travis_wait 60 bundle exec rake litmus:acceptance:parallel
@@ -51,7 +51,7 @@ matrix:
       rvm: 2.5.1
       script:
       - bundle exec rake 'litmus:provision_list[travis_deb]'
-      - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --nodes='localhost*'
+      - bundle exec bolt command run 'apt-get install wget -y' --inventoryfile inventory.yaml --targets='localhost*'
       - bundle exec rake 'litmus:install_agent[puppet6]'
       - bundle exec rake litmus:install_module
       - travis_wait 60 bundle exec rake litmus:acceptance:parallel

--- a/plans/patch_after_healthcheck.pp
+++ b/plans/patch_after_healthcheck.pp
@@ -6,7 +6,7 @@ plan os_patching::patch_after_healthcheck (
   TargetSpec $nodes,
   Optional[Boolean] $noop_state = false,
   Optional[Integer] $runinterval = 1800,
-  ) {  
+  ) {
   # Run an initial health check to make sure the target nodes are ready
 
   $health_checks = run_task('puppet_health_check::agent_health',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,6 +2,7 @@
 
 require 'serverspec'
 require 'puppet_litmus'
+require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 include PuppetLitmus
 
 if ENV['TARGET_HOST'].nil? || ENV['TARGET_HOST'] == 'localhost'
@@ -16,13 +17,41 @@ else
   inventory_hash = inventory_hash_from_inventory_file
   node_config = config_from_node(inventory_hash, ENV['TARGET_HOST'])
 
-  if target_in_group(inventory_hash, ENV['TARGET_HOST'], 'ssh_nodes')
+  if target_in_group(inventory_hash, ENV['TARGET_HOST'], 'docker_nodes')
+    host = ENV['TARGET_HOST']
+    set :backend, :docker
+    set :docker_container, host
+  elsif target_in_group(inventory_hash, ENV['TARGET_HOST'], 'ssh_nodes')
     set :backend, :ssh
     options = Net::SSH::Config.for(host)
     options[:user] = node_config.dig('ssh', 'user') unless node_config.dig('ssh', 'user').nil?
     options[:port] = node_config.dig('ssh', 'port') unless node_config.dig('ssh', 'port').nil?
+    options[:keys] = node_config.dig('ssh', 'private-key') unless node_config.dig('ssh', 'private-key').nil?
     options[:password] = node_config.dig('ssh', 'password') unless node_config.dig('ssh', 'password').nil?
-    options[:verify_host_key] = Net::SSH::Verifiers::Null.new unless node_config.dig('ssh', 'host-key-check').nil?
+    # Support both net-ssh 4 and 5.
+    # rubocop:disable Metrics/BlockNesting
+    options[:verify_host_key] = if node_config.dig('ssh', 'host-key-check').nil?
+                                  # Fall back to SSH behavior. This variable will only be set in net-ssh 5.3+.
+                                  if @strict_host_key_checking.nil? || @strict_host_key_checking
+                                    Net::SSH::Verifiers::Always.new
+                                  else
+                                    # SSH's behavior with StrictHostKeyChecking=no: adds new keys to known_hosts.
+                                    # If known_hosts points to /dev/null, then equivalent to :never where it
+                                    # accepts any key beacuse they're all new.
+                                    Net::SSH::Verifiers::AcceptNewOrLocalTunnel.new
+                                  end
+                                elsif node_config.dig('ssh', 'host-key-check')
+                                  if defined?(Net::SSH::Verifiers::Always)
+                                    Net::SSH::Verifiers::Always.new
+                                  else
+                                    Net::SSH::Verifiers::Secure.new
+                                  end
+                                elsif defined?(Net::SSH::Verifiers::Never)
+                                  Net::SSH::Verifiers::Never.new
+                                else
+                                  Net::SSH::Verifiers::Null.new
+                                end
+    # rubocop:enable Metrics/BlockNesting
     host = if ENV['TARGET_HOST'].include?(':')
              ENV['TARGET_HOST'].split(':').first
            else

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,7 +29,6 @@ else
     options[:keys] = node_config.dig('ssh', 'private-key') unless node_config.dig('ssh', 'private-key').nil?
     options[:password] = node_config.dig('ssh', 'password') unless node_config.dig('ssh', 'password').nil?
     # Support both net-ssh 4 and 5.
-    # rubocop:disable Metrics/BlockNesting
     options[:verify_host_key] = if node_config.dig('ssh', 'host-key-check').nil?
                                   # Fall back to SSH behavior. This variable will only be set in net-ssh 5.3+.
                                   if @strict_host_key_checking.nil? || @strict_host_key_checking
@@ -51,7 +50,6 @@ else
                                 else
                                   Net::SSH::Verifiers::Null.new
                                 end
-    # rubocop:enable Metrics/BlockNesting
     host = if ENV['TARGET_HOST'].include?(':')
              ENV['TARGET_HOST'].split(':').first
            else


### PR DESCRIPTION
I updated `spec_helper_acceptance.rb` with the one from a Puppetlabs module:

https://github.com/puppetlabs/puppetlabs-ntp/blob/master/spec/spec_helper_acceptance.rb

This seems to allow the tests to pass.

I also tried to get rid of a few deprecation warnings by changing the syntax of a few commands.