### PR TITLE
Working on #180 : Adding rescue to allow code to continue after NoMet…

### DIFF
--- a/files/os_patching_fact_generation.sh
+++ b/files/os_patching_fact_generation.sh
@@ -58,7 +58,7 @@ CATALOG="$(facter -p puppet_vardir)/client_data/catalog/$(puppet config print ce
 
 if [ -f "${CATALOG}" ]
 then
-	VERSION_LOCK_FROM_CATALOG=$(cat $CATALOG | /opt/puppetlabs/puppet/bin/ruby -e "require 'json'; json_hash = JSON.parse(ARGF.read); json_hash['resources'].select { |r| r['type'] == 'Package' and r['parameters']['ensure'].match /\d.+/ }.each do | m | puts m['title'] end")
+	VERSION_LOCK_FROM_CATALOG=$(cat $CATALOG | /opt/puppetlabs/puppet/bin/ruby -e "require 'json'; json_hash = JSON.parse(ARGF.read); json_hash['resources'].select { |r| r['type'] == 'Package' and ((r['parameters']['ensure'].match /\d.+/) rescue false) }.each do | m | puts m['title'] end")
 else
 	VERSION_LOCK_FROM_CATALOG=''
 fi


### PR DESCRIPTION
Adding rescue to allow code to continue after NoMethodError on .match

I am seeing in the contributing guidelines that this almost certainly is below the mark to do this right, but I'm not in a place where I can get my environment set up like that at present.  Still submitting in case this is helpful, but apologies for the lack of procedure.