### PR TITLE
Working on #192: Adding dot character to char list for Login user col…

### DIFF
--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -476,7 +476,7 @@ if facts['values']['os']['family'] == 'RedHat'
       # ID     | Login user               | Date and time    | 8< SNIP >8
       # ------------------------------------------------------ 8< SNIP >8
       #     69 | System <unset>           | 2018-09-17 17:18 | 8< SNIP >8
-      matchdata = line.to_s.match(/^\s+(\d+)\s*\|\s*[\w\-<> ]*\|\s*([\d:\- ]*)/)
+      matchdata = line.to_s.match(/^\s+(\d+)\s*\|\s*[\w\.\-<> ]*\|\s*([\d:\- ]*)/)
       next unless matchdata
       job = matchdata[1]
       yum_end = matchdata[2]


### PR DESCRIPTION
…umn.

For #192 

This allows `yum history` output to be parsed correctly when users with long names get ellipsized like so:

```
$ sudo yum history
[snip]
ID     | Login user               | Date and time    | Action(s)      | Altered
-------------------------------------------------------------------------------
   122 | Bob ... <username>       | 2021-02-10 09:18 | Update         |    7
```

Before this change, the above output would result in "Yum did not appear to run".