### PR TITLE
Update Apt Support - Fixes #217

### DIFF
--- a/files/os_patching_fact_generation.sh
+++ b/files/os_patching_fact_generation.sh
@@ -49,7 +49,7 @@ case $OSFAMILY in
   Debian)
     apt update >/dev/null 2>&1
     PKGS=$(apt upgrade -s 2>/dev/null | awk '$1 == "Inst" {print $2}')
-    SECPKGS=$(apt upgrade -s 2>/dev/null | awk '$1 == "Inst" && /Security/ {print $2}')
+    SECPKGS=$(apt upgrade -s 2>/dev/null | awk 'BEGIN {IGNORECASE = 1}; $1 == "Inst" && /Security/ {print $2}')
     HELDPKGS=$(dpkg --get-selections | awk '$2 == "hold" {print $1}')
   ;;
   FreeBSD)

--- a/files/os_patching_fact_generation.sh
+++ b/files/os_patching_fact_generation.sh
@@ -47,6 +47,7 @@ case $OSFAMILY in
     HELDPKGS=$(zypper --non-interactive --no-abbrev --quiet ll | grep '|' | grep -v '^Repository' | awk -F'|' '/^[[:alnum:]]/ {print $2}' | sed 's/^\s*\|\s*$//')
   ;;
   Debian)
+    apt update >/dev/null 2>&1
     PKGS=$(apt upgrade -s 2>/dev/null | awk '$1 == "Inst" {print $2}')
     SECPKGS=$(apt upgrade -s 2>/dev/null | awk '$1 == "Inst" && /Security/ {print $2}')
     HELDPKGS=$(dpkg --get-selections | awk '$2 == "hold" {print $1}')


### PR DESCRIPTION
Apt requires users to run `apt update` to update the package list. Without this, there will never be any updates for `apt upgrade` to upgrade.