### PR TITLE
fix issue #211

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -307,7 +307,7 @@ class os_patching (
 
   if $fact_upload_exec and $fact_upload {
     exec { $fact_upload_exec:
-      command     => "'${puppet_binary}' facts upload",
+      command     => "\"${puppet_binary}\" facts upload",
       path        => ['/opt/puppetlabs/bin/', '/usr/bin','/bin','/sbin','/usr/local/bin'],
       refreshonly => true,
       subscribe   => File[


### PR DESCRIPTION
Add double quotation marks instead of single, Fixes #211

With single quotation marks
```
Debug: Exec[test](provider=windows): Executing ''C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat' facts upload'
Debug: Executing: ''C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat' facts upload'
Error: No such file or directory - CreateProcess
Error: /Stage[main]/Main/Exec[test]/returns: change from 'notrun' to ['0'] failed: No such file or directory - CreateProcess
```

With double quotation marks
```
Debug: Exec[test](provider=windows): Executing '"C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat" facts upload'
Debug: Executing: '"C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat" facts upload'
Notice: /Stage[main]/Main/Exec[test]/returns: executed successfully
```