### PR TITLE
Don't record note from subscription-manager if enabled

### DIFF
--- a/files/os_patching_fact_generation.sh
+++ b/files/os_patching_fact_generation.sh
@@ -133,10 +133,10 @@ then
       else
         echo "false" > $DATADIR/reboot_required
       fi
-      /usr/bin/needs-restarting 2>/dev/null | sed 's/[[:space:]]*$//' >$DATADIR/apps_to_restart
+      /usr/bin/needs-restarting 2>/dev/null | grep -v 'Updating Subscription Management repositories' | sed 's/[[:space:]]*$//' >$DATADIR/apps_to_restart
     ;;
     6)
-      /usr/bin/needs-restarting 2>/dev/null 1>$DATADIR/apps_to_restart
+      /usr/bin/needs-restarting 2>/dev/null | grep -v 'Updating Subscription Management repositories' > $DATADIR/apps_to_restart
       if [ $? -gt 0 ]
       then
         echo "true" > $DATADIR/reboot_required


### PR DESCRIPTION
Subscription-manager will occasionally report `Updating Subscription Management repositories.` if things are out of sync.  This ends up putting a meaningless line within the apps list.  The provided patch filters out the informational message.