### PR TITLE
Add feature to disable fact generation shell script

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,7 @@
 ---
+os_patching::fact_cron: true
 os_patching::fact_upload: true
+os_patching::use_shell_script: true
 os_patching::pre_patching_command: NULL
 os_patching::block_patching_on_warnings: false
 os_patching::reboot_override: 'default'

--- a/lib/facter/os_patching.rb
+++ b/lib/facter/os_patching.rb
@@ -9,6 +9,7 @@ if Facter.value(:facterversion).split('.')[0].to_i < 2
   end
 else
   Facter.add('os_patching', :type => :aggregate) do
+
     confine { ['FreeBSD', 'Linux', 'windows'].include?(Facter.value(:kernel)) }
     require 'time'
     now = Time.now.iso8601
@@ -19,8 +20,19 @@ else
     case Facter.value(:kernel)
     when 'FreeBSD', 'Linux'
       os_patching_dir = '/var/cache/os_patching'
+      os_patching_shell_script = '/usr/local/bin/os_patching_fact_generation.sh'
     when 'windows'
       os_patching_dir = 'C:\ProgramData\os_patching'
+    end
+
+    use_shell_script = File.file?(os_patching_shell_script)
+    unless use_shell_script
+      pkgs = `yum -q check-update 2>/dev/null | egrep -v "^[Ss]ecurity:" | grep -oP '^.*?(?= )' | sed 's/Obsoleting.*//'`.split("\n")
+      sec_pkgs = `yum -q --security check-update 2>/dev/null | egrep -v "^Security:" | grep -oP '^.*?(?= )' | sed 's/Obsoleting.*//'`.split("\n")
+      held_pkgs = `[ -r /etc/yum/pluginconf.d/versionlock.list ] && awk -F':' '/:/ {print $2}' /etc/yum/pluginconf.d/versionlock.list | sed 's/-[0-9].*//'`.split("\n")
+
+      vardir = `puppet config print vardir`.strip
+      catalog = vardir + "/client_data/catalog/" + `puppet config print certname --section agent`.strip + ".json"
     end
 
     chunk(:agent_type) do
@@ -35,26 +47,32 @@ else
 
     chunk(:updates) do
       data = {}
-      updatelist = []
-      updatefile = os_patching_dir + '/package_updates'
-      if File.file?(updatefile)
-        if (Time.now - File.mtime(updatefile)) / (24 * 3600) > 10
-          warnings['update_file_time'] = 'Update file has not been updated in 10 days'
-        end
+      if use_shell_script
+        updatelist = []
+        updatefile = os_patching_dir + '/package_updates'
+        if File.file?(updatefile)
+          if (Time.now - File.mtime(updatefile)) / (24 * 3600) > 10
+            warnings['update_file_time'] = 'Update file has not been updated in 10 days'
+          end
 
-        updates = File.open(updatefile, 'r').read
-        updates.each_line do |line|
-          next unless line =~ /[A-Za-z0-9]+/
-          next if line =~ /^#|^$/
-          line.sub! 'Title : ', ''
-          updatelist.push line.chomp
+          updates = File.open(updatefile, 'r').read
+          updates.each_line do |line|
+            next unless line =~ /[A-Za-z0-9]+/
+            next if line =~ /^#|^$/
+            line.sub! 'Title : ', ''
+            updatelist.push line.chomp
+          end
+        else
+          warnings['update_file'] = 'Update file not found, update information invalid'
         end
+        data['package_updates'] = updatelist
+        data['package_update_count'] = updatelist.count
+        data
       else
-        warnings['update_file'] = 'Update file not found, update information invalid'
+        data['package_updates'] = pkgs
+        data['package_update_count'] = pkgs.count
+        data
       end
-      data['package_updates'] = updatelist
-      data['package_update_count'] = updatelist.count
-      data
     end
 
     chunk(:kb_updates) do
@@ -73,24 +91,30 @@ else
 
     chunk(:secupdates) do
       data = {}
-      secupdatelist = []
-      secupdatefile = os_patching_dir + '/security_package_updates'
-      if File.file?(secupdatefile)
-        if (Time.now - File.mtime(secupdatefile)) / (24 * 3600) > 10
-          warnings['sec_update_file_time'] = 'Security update file has not been updated in 10 days'
+      if use_shell_script
+        secupdatelist = []
+        secupdatefile = os_patching_dir + '/security_package_updates'
+        if File.file?(secupdatefile)
+          if (Time.now - File.mtime(secupdatefile)) / (24 * 3600) > 10
+            warnings['sec_update_file_time'] = 'Security update file has not been updated in 10 days'
+          end
+          secupdates = File.open(secupdatefile, 'r').read
+          secupdates.each_line do |line|
+            next if line.empty?
+            next if line =~ /^#|^$/
+            secupdatelist.push line.chomp
+          end
+        else
+          warnings['security_update_file'] = 'Security update file not found, update information invalid'
         end
-        secupdates = File.open(secupdatefile, 'r').read
-        secupdates.each_line do |line|
-          next if line.empty?
-          next if line =~ /^#|^$/
-          secupdatelist.push line.chomp
-        end
+        data['security_package_updates'] = secupdatelist
+        data['security_package_update_count'] = secupdatelist.count
+        data
       else
-        warnings['security_update_file'] = 'Security update file not found, update information invalid'
+        data['security_package_updates'] = sec_pkgs
+        data['security_package_update_count'] = sec_pkgs.count
+        data
       end
-      data['security_package_updates'] = secupdatelist
-      data['security_package_update_count'] = secupdatelist.count
-      data
     end
 
     chunk(:blackouts) do
@@ -132,24 +156,44 @@ else
     # Are there any pinned/version locked packages?
     chunk(:pinned) do
       data = {}
-      pinnedpkgs = []
-      mismatchpinnedpackagefile = os_patching_dir + '/mismatched_version_locked_packages'
-      pinnedpackagefile = os_patching_dir + '/os_version_locked_packages'
-      if File.file?(pinnedpackagefile)
-        pinnedfile = File.open(pinnedpackagefile, 'r').read.chomp
-        pinnedfile.each_line do |line|
-          pinnedpkgs.push line.chomp
+      if use_shell_script
+        pinnedpkgs = []
+        mismatchpinnedpackagefile = os_patching_dir + '/mismatched_version_locked_packages'
+        pinnedpackagefile = os_patching_dir + '/os_version_locked_packages'
+        if File.file?(pinnedpackagefile)
+          pinnedfile = File.open(pinnedpackagefile, 'r').read.chomp
+          pinnedfile.each_line do |line|
+            pinnedpkgs.push line.chomp
+          end
         end
-      end
-      if File.file?(mismatchpinnedpackagefile) && !File.zero?(mismatchpinnedpackagefile)
-        warnings['version_specified_but_not_locked_packages'] = []
-        mismatchfile = File.open(mismatchpinnedpackagefile, 'r').read
-        mismatchfile.each_line do |line|
-          warnings['version_specified_but_not_locked_packages'].push line.chomp
+        if File.file?(mismatchpinnedpackagefile) && !File.zero?(mismatchpinnedpackagefile)
+          warnings['version_specified_but_not_locked_packages'] = []
+          mismatchfile = File.open(mismatchpinnedpackagefile, 'r').read
+          mismatchfile.each_line do |line|
+            warnings['version_specified_but_not_locked_packages'].push line.chomp
+          end
         end
+        data['pinned_packages'] = pinnedpkgs
+        data
+      else
+        require 'json'
+        pinned_list = []
+
+        File.open(catalog, 'r') do |file|
+          json_hash = JSON.load file
+          json_hash['resources'].select { |r| r['type'] == 'Package' and r['parameters'] and r['parameters']['ensure'] and r['parameters']['ensure'].match /\d.+/ }.each do | m |
+            pinned_list.push(m['title'])
+          end
+        end
+        data['pinned_packages'] = pinned_list
+
+        pinned_list.each do | pkg |
+          if held_pkgs.include?(pkg)
+            warnings['version_specified_but_not_locked_packages'].push pkg
+          end
+        end
+        data
       end
-      data['pinned_packages'] = pinnedpkgs
-      data
     end
 
     # History info
@@ -222,39 +266,59 @@ else
     chunk(:reboot_required) do
       data = {}
       data['reboots'] = {}
-      reboot_required_file = os_patching_dir + '/reboot_required'
-      if File.file?(reboot_required_file)
-        if (Time.now - File.mtime(reboot_required_file)) / (24 * 3600) > 10
-          warnings['reboot_required_file_time'] = 'Reboot required file has not been updated in 10 days'
+
+      if use_shell_script
+        reboot_required_file = os_patching_dir + '/reboot_required'
+        if File.file?(reboot_required_file)
+          if (Time.now - File.mtime(reboot_required_file)) / (24 * 3600) > 10
+            warnings['reboot_required_file_time'] = 'Reboot required file has not been updated in 10 days'
+          end
+          reboot_required_fh = File.open(reboot_required_file, 'r').to_a
+          data['reboots']['reboot_required'] = case reboot_required_fh.last
+                                              when /^[Tt]rue$/
+                                                true
+                                              when /^[Ff]alse$/
+                                                false
+                                              else
+                                                ''
+                                              end
+        else
+          data['reboots']['reboot_required'] = 'unknown'
         end
-        reboot_required_fh = File.open(reboot_required_file, 'r').to_a
-        data['reboots']['reboot_required'] = case reboot_required_fh.last
-                                             when /^[Tt]rue$/
-                                               true
-                                             when /^[Ff]alse$/
-                                               false
-                                             else
-                                               ''
-                                             end
+        app_restart_file = os_patching_dir + '/apps_to_restart'
+        if File.file?(app_restart_file)
+          app_restart_fh = File.open(app_restart_file, 'r').to_a
+          data['reboots']['apps_needing_restart'] = {}
+          app_restart_fh.each do |line|
+            line.chomp!
+            key_value = line.split(' : ')
+            data['reboots']['apps_needing_restart'][key_value[0]] = key_value[1]
+          end
+          data['reboots']['app_restart_required'] = if data['reboots']['apps_needing_restart'].empty?
+                                                      false
+                                                    else
+                                                      true
+                                                    end
+        end
+        data
       else
-        data['reboots']['reboot_required'] = 'unknown'
-      end
-      app_restart_file = os_patching_dir + '/apps_to_restart'
-      if File.file?(app_restart_file)
-        app_restart_fh = File.open(app_restart_file, 'r').to_a
-        data['reboots']['apps_needing_restart'] = {}
-        app_restart_fh.each do |line|
-          line.chomp!
-          key_value = line.split(' : ')
-          data['reboots']['apps_needing_restart'][key_value[0]] = key_value[1]
+        reboot = `/usr/bin/needs-restarting -r 2>/dev/null 1>/dev/null`.split("\n")
+        unless reboot.empty?
+          data['reboots']['reboot_required'] = true
+        else
+          data['reboots']['reboot_required'] = false
         end
-        data['reboots']['app_restart_required'] = if data['reboots']['apps_needing_restart'].empty?
-                                                    false
-                                                  else
-                                                    true
-                                                  end
+
+        apps_restart = `/usr/bin/needs-restarting 2>/dev/null | grep -v 'Updating Subscription Management repositories' | sed 's/[[:space:]]*$//'`.split("\n")
+        data['reboots']['apps_needing_restart'] = apps_restart
+
+        unless data['reboots']['apps_needing_restart'].empty?
+          data['reboots']['app_restart_required'] = true
+        else
+          data['reboots']['app_restart_required'] = false
+        end
+        data
       end
-      data
     end
 
     # Should we patch if there are warnings?

--- a/tasks/patch_server.rb
+++ b/tasks/patch_server.rb
@@ -247,13 +247,13 @@ end
 
 log.info 'os_patching run started'
 
-# ensure node has been tagged with os_patching class by checking for fact generation script
+# ensure node has been tagged with os_patching class by checking for fact cache directory
 log.debug 'Running os_patching fact refresh'
-unless File.exist? fact_generation_script
+unless Dir.exist? '/var/cache/os_patching'
   err(
     255,
-    "os_patching/#{fact_generation_script}",
-    "#{fact_generation_script} does not exist, declare os_patching and run Puppet first",
+    "/var/cache/os_patching",
+    "/var/cache/os_patching does not exist, declare os_patching and run Puppet first",
     starttime,
   )
 end
@@ -299,7 +299,7 @@ end
 # Refresh the patching fact cache on non-windows systems
 # Windows scans can take a long time, and we do one at the start of the os_patching_windows script anyway.
 # No need to do yet another scan prior to this, it just wastes valuable time.
-if os['family'] != 'windows'
+if os['family'] != 'windows' and File.exist? fact_generation_script
   _fact_out, stderr, status = Open3.capture3(fact_generation_cmd)
   err(status, 'os_patching/fact_refresh', stderr, starttime) if status != 0
 end
@@ -648,7 +648,7 @@ end
 # Windows scans can take an eternity after a patch run prior to being reboot (30+ minutes in a lab on 2008 versions..)
 # Best not to delay the whole patching process here.
 # Note that the fact refresh (which includes a scan) runs on system startup anyway - see os_patching puppet class
-if os['family'] != 'windows'
+if os['family'] != 'windows' and File.exist? fact_generation_script
   log.info 'Running os_patching fact refresh'
   _fact_out, stderr, status = Open3.capture3(fact_generation_cmd)
   err(status, 'os_patching/fact', stderr, starttime) if status != 0


### PR DESCRIPTION
`puppet facts upload` used in the fact generation script is able to unintentionally overwrite the environment fact. This adds a feature flag to disable the fact generation shell script. If this script is disabled, the relevant facts will now be resolved within the Facter script itself. This primarily affects the facts generated by package management tools.