### PR TITLE
Fact upload not working correctly for windows due to path is NIX specific

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -308,7 +308,7 @@ class os_patching (
   if $fact_upload_exec and $fact_upload {
     $puppet_binary_path = $facts['os']['family'] ? {
       'windows' => 'C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat',
-      default   => '/opt/puppet/bin/puppet',
+      default   => '/opt/puppetlabs/bin/puppet',
     }
 
     exec { $fact_upload_exec:


### PR DESCRIPTION
…ific. Added windows executable path

Error on windows:

Error: /Stage[main]/Os_patching/Exec[os_patching::exec::fact_upload]: Failed to call refresh: Could not find command '/opt/puppetlabs/bin/puppet'
Error: /Stage[main]/Os_patching/Exec[os_patching::exec::fact_upload]: Could not find command '/opt/puppetlabs/bin/puppet'

Now working correctly for windows as well:

Info: /Stage[main]/Os_patching/File[C:/ProgramData/os_patching]: Scheduling refresh of Exec[os_patching::exec::fact_upload]
Notice: /Stage[main]/Os_patching/File[C:/ProgramData/os_patching/os_patching_fact_generation.ps1]/ensure: defined content as '{sha256}6baedcd3b32bb3359fd20ba9942def3ed595a6205c4b07daa8bf290fcc79efd9' (corrective)
Info: /Stage[main]/Os_patching/File[C:/ProgramData/os_patching/os_patching_fact_generation.ps1]: Scheduling refresh of Exec[os_patching::exec::fact]
Info: /Stage[main]/Os_patching/File[C:/ProgramData/os_patching/os_patching_fact_generation.ps1]: Scheduling refresh of Exec[os_patching::exec::fact_upload]
Notice: /Stage[main]/Os_patching/File[C:/ProgramData/os_patching/patch_window]/ensure: defined content as '{sha256}bcbe4af70688633b6d8d5e6e16647e486e7edc2db12e67f679d4a09a76fd7fab' (corrective)
Info: /Stage[main]/Os_patching/File[C:/ProgramData/os_patching/patch_window]: Scheduling refresh of Exec[os_patching::exec::fact_upload]
Notice: /Stage[main]/Os_patching/File[C:/ProgramData/os_patching/reboot_override]/ensure: defined content as '{sha256}37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f' (corrective)
Info: /Stage[main]/Os_patching/File[C:/ProgramData/os_patching/reboot_override]: Scheduling refresh of Exec[os_patching::exec::fact_upload]
Notice: /Stage[main]/Os_patching/Exec[os_patching::exec::fact_upload]: Triggered 'refresh' from 4 events
Notice: /Stage[main]/Os_patching/Exec[os_patching::exec::fact]: Triggered 'refresh' from 1 event