### PR TITLE
fix README and REFERENCE not adhering to Puppet Code or ISO8601

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ More advanced usage:
 ```puppet
 class { 'os_patching':
   patch_window     => 'Week3',
-  blackout_windows => { 'End of year change freeze':
-    {
-      'start': '2018-12-15T00:00:00+1000',
-      'end':   '2019-01-15T23:59:59+1000',
-    }
+  blackout_windows => {
+    'End of year change freeze' => {
+      'start' => '2018-12-15T00:00:00+10:00',
+      'end'   => '2019-01-15T23:59:59+10:00',
+    },
   },
 }
 ```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -37,11 +37,11 @@ the `os_patching` fact.
 class { 'os_patching':
   patch_window     => 'Week3',
   reboot_override  => 'always',
-  blackout_windows => { 'End of year change freeze':
-    {
-      'start': '2018-12-15T00:00:00+10:00',
-      'end': '2019-01-15T23:59:59+10:00',
-    }
+  blackout_windows => {
+    'End of year change freeze' => {
+      'start' => '2018-12-15T00:00:00+10:00',
+      'end'   => '2019-01-15T23:59:59+10:00',
+    },
   },
 }
 ```


### PR DESCRIPTION
The code in README and REFERENCE both would fail with

1. Syntax error at the first colon encountered in "blackout_windows"
2. "Evaluation Error: Error while evaluating a Function Call, Blackout start time must be in ISO 8601 format (YYYY-MM-DDTmm:hh:ss[-+]hh:mm)"

This PR would fix the examples.